### PR TITLE
lesson 2 - ipAddressFilter and cli-reader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 
 # testing
 /coverage
+
+#bigFiles
+*.log

--- a/lesson-2/cli-reader.mjs
+++ b/lesson-2/cli-reader.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+
+import { program } from 'commander';
+import inquirer from 'inquirer';
+import fs from 'fs';
+import path from 'path';
+import readline from 'readline';
+
+program
+  .description('CLI to some utilities')
+  .option('-f, --files', 'list of files for the current directory')
+  .option('-fd, --filesInDirectory <string>', 'list of files for the set directory')
+  .option('-e, --explorer', 'start File Explorer')
+  .option('-p, --pattern <string>', "regex pattern to filter file's content")
+  
+program.parse();
+
+const options = program.opts();
+
+const currentDirectory = process.cwd();
+
+const isFile = (file, currentDirectory) => {
+  if (!currentDirectory) {
+    currentDirectory = program.cwd();
+  }
+  const fullPath = path.join(currentDirectory, file);
+
+  return fs.lstatSync(fullPath).isFile()
+};
+const isDirectory = (directory, currentDirectory) => {
+  if (!currentDirectory) {
+    currentDirectory = program.cwd();
+  }
+  const fullPath = path.join(currentDirectory, directory);
+
+  return fs.lstatSync(fullPath).isDirectory();
+}
+
+if (options.files || (!options.filesInDirectory && !options.explorer)) {
+  readFile(currentDirectory, isFile);
+}
+if (options.filesInDirectory) {
+  const pathToDirectory = options.filesInDirectory;
+  readFile(pathToDirectory, isFile);
+}
+if (options.explorer) {
+  startFileExplorer(currentDirectory, isDirectory, isFile)
+}
+
+function readFile(pathToDirectory) {
+  const list = fs.readdirSync(pathToDirectory)
+                  .filter((file) => isFile(file, pathToDirectory));
+
+  inquirer
+    .prompt([
+      {
+        name: "name",
+        type: "list",
+        message: "Choose file:",
+        choices: list
+      }
+    ])
+    .then((answer) => {
+      const fullPath = path.join(pathToDirectory, answer.name);
+      printFile(fullPath, options.pattern);
+    })
+}
+
+function startFileExplorer(pathToDirectory) {
+  let list = fs.readdirSync(pathToDirectory);
+
+  inquirer
+    .prompt([
+      {
+        name: "name",
+        type: "list",
+        message: `${pathToDirectory} ->`,
+        choices: list
+      }
+    ])
+    .then((answer) => {
+      const fullPath = path.join(pathToDirectory, answer.name);
+      if (isDirectory(answer.name, pathToDirectory)) {
+        startFileExplorer(fullPath);
+      }
+      if (isFile(answer.name, pathToDirectory)) {
+        printFile(fullPath, options.pattern);
+      }
+    })
+}
+
+function printFile(fullPath, pattern) {
+  if (pattern) {
+    printFileWithFilter(fullPath, pattern);
+    return;
+  }
+  
+  fs.readFile(fullPath, 'utf-8', (_, data) => {
+    console.log(data);
+  })
+}
+
+function printFileWithFilter(fullPath, pattern) {
+  const readStream = fs.createReadStream(fullPath, { encoding: 'utf-8' });
+  const rl = readline.createInterface(readStream);
+  const regex = new RegExp(pattern);
+  let content = `Filter content with pattern '${pattern}': \n`;
+
+  rl
+    .on('line', (line) => {
+      if (regex.test(line)) {
+        content += line + '\n';
+      }
+    })
+    .on('close', () => console.log(content));
+}

--- a/lesson-2/createFile100Mb.ts
+++ b/lesson-2/createFile100Mb.ts
@@ -1,0 +1,23 @@
+import fs from "fs";
+
+const FILENAME = "./lesson-2/access.log";
+const recordTemplate = " - [30/Jan/2021:11:11:20 -0300] POST /foo HTTP/1.1 200 0 - curl/7.47.0" + "\n";
+
+let size = 0;
+do {
+    fs.appendFileSync(FILENAME, getRandomIPAddress() + recordTemplate);
+    size = fs.statSync(FILENAME).size;
+} while (size < 1e8)
+
+function getRandomIPAddress(): string {
+    let ip = getRandomNumber(1, 256) + ".";
+    ip += getRandomNumber(0, 256) + ".";
+    ip += getRandomNumber(0, 256) + ".";
+    ip += getRandomNumber(0, 256);
+
+    return ip;
+}
+
+function getRandomNumber(min: number, max: number): number {
+    return Math.floor(Math.random() * (max - min) + min); 
+}

--- a/lesson-2/index.ts
+++ b/lesson-2/index.ts
@@ -1,0 +1,12 @@
+import { ipAddressFilter } from "./ipAddressFilter";
+
+if (process.argv.length < 4) {
+    console.log("Please specify a number of task and required arguments");
+}
+
+const taskNumber = process.argv[2];
+switch (taskNumber) {
+    case "1":
+        ipAddressFilter(process.argv.slice(3));
+        break;
+}

--- a/lesson-2/ipAddressFilter.ts
+++ b/lesson-2/ipAddressFilter.ts
@@ -1,0 +1,44 @@
+import { createReadStream, createWriteStream, WriteStream } from "fs";
+import readLine from 'readline';
+
+export function ipAddressFilter([logFile, filterStr]: string[]) {
+    filterRequestToFile(logFile, filterStr);
+}
+
+function filterRequestToFile(logFile: string, filterStr: string) {
+    
+    const readStream = createReadStream(logFile, { encoding: 'utf-8'});
+    const rl = readLine.createInterface(readStream);
+
+    const pattern = getPatternToRegEx(filterStr);
+    const regex = new RegExp(pattern, 'g');
+    
+    const writeStream: WriteStream = getWriteStream(filterStr);
+    rl
+        .on('line', (line) => {
+            if (regex.test(line)) {
+                writeStream.write(line + '\n');
+            }
+        })
+        .on('close', () => writeStream?.close());
+}
+
+function getPatternToRegEx(filterStr: string): string {
+    let pattern = filterStr
+                    .replace("*", "\\d+")
+                    .replace(".", "\\.");
+    
+    return pattern;
+}
+
+function getWriteStream(filterStr: string): WriteStream {
+    const fileName = filterStr.replace(/\./g, "_")
+                                .replace(/\*/g, "any");
+    
+    const writeStream = createWriteStream(`./lesson-2/${fileName}_requests.log`, {
+        encoding: 'utf-8',
+        flags: 'a'
+    })
+
+    return writeStream;
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "ts-node ./lesson-1/index.ts",
+    "start": "ts-node ./lesson-2/index.ts",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],
@@ -21,5 +21,8 @@
     "commander": "^9.4.0",
     "inquirer": "^9.1.0",
     "readline": "^1.3.0"
+  },
+  "bin": {
+    "cli-reader": "./lesson-2/cli-reader.mjs"
   }
 }


### PR DESCRIPTION
Основное задание к уроку №2 было выполнено, как дополнительное к уроку №1.
Выполнены все дополнительные задания:
1) ipAddressFilter.ts - фильтр текстового файла по заданному паттерну (задается ip-адрес полностью "89.123.1.41" или частично "89.*.1.41", тогда вместо "*" подставляется шаблон регулярного выражения "\d+").
Пример запуска: npm start 1 [путь до файла] [шаблон].
Сгенерированный файл access.log заархивирован для обхода ограничений GitHub.
2) cli-reader.mjs - консольное приложение для чтения файлов с возможностью задания фильтра содержимого.